### PR TITLE
토큰 인증이 필요없는 엔드포인트는 인증 절차를 안 거치게 설정

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/SecurityConfig.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package com.toyProject7.karrot
 
 import com.toyProject7.karrot.security.JwtAuthenticationFilter
+import com.toyProject7.karrot.security.SecurityConstants
 import com.toyProject7.karrot.socialLogin.handler.CustomAuthenticationSuccessHandler
 import com.toyProject7.karrot.socialLogin.service.SocialLoginUserService
 import org.springframework.context.annotation.Bean
@@ -26,9 +27,7 @@ class SecurityConfig(
             .authorizeHttpRequests { registry ->
                 registry
                     .requestMatchers(
-                        "/api/auth/**",
-                        "/oauth2/**",
-                        "/auth/**",
+                        *SecurityConstants.PUBLIC_PATHS,
                     ).permitAll()
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/com/toyProject7/karrot/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/security/SecurityConstants.kt
@@ -1,0 +1,10 @@
+package com.toyProject7.karrot.security
+
+object SecurityConstants {
+    val PUBLIC_PATHS =
+        arrayOf(
+            "/api/auth/**",
+            "/oauth2/**",
+            "/auth/**",
+        )
+}


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈


## ✨ 주요 변경 사항
- [√] 백엔드: 토큰 인증이 필요없는 엔드포인트는 인증 절차를 안 거치게 설정

---

## 📋 작업 내용
### 추가/변경된 내용
- SecurityConfig와 JwtAuthenticationFilter에서 하는 토큰인증을 같은 path에 대해서 하게 설정

### 작업 상세 설명
1. 현재까진 SecurityConfig에서 토큰인증 제외 목록 따로, JwtAuthenticationFilter에 토크인증 제외 목록이 따로 하드코딩되어있었다.
2. 이제는 SecurityConstants를 생성하여 여기에 PUBLIC_PATH에 있는 endpoint는 동시에 제외 되게 설정.

---

## ✅ 체크리스트
- [√ ] 코드가 잘 빌드됨
- [ √] Linter
- [ √] 모든 테스트 통과
- [ √] kanban update