### PR TITLE
CORS에 프론트엔드 개발 환경 추가

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/SecurityConfig.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/SecurityConfig.kt
@@ -57,7 +57,11 @@ class SecurityConfig(
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
-        configuration.allowedOrigins = listOf("https://toykarrot.shop")
+        configuration.allowedOrigins =
+            listOf(
+                "https://toykarrot.shop",
+                "http://localhost:5173",
+            )
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
         configuration.allowedHeaders = listOf("*")
         configuration.allowCredentials = true


### PR DESCRIPTION
## 🔍 관련 이슈
- 이슈 번호: #16 

## ✨ 주요 변경 사항
- [√] 백엔드: Spring Boot 관련 기능 추가/수정

---

## 📋 작업 내용
### 추가/변경된 내용
- 프론트 개발 서버 cors에 추가

### 작업 상세 설명
1. allowedOrigins에 http://localhost:5173추가. 이러면 cors 에러없이 프론트 개발 서버에서도 백엔드 데이터베이스를 이용할수있다.

---

## ✅ 체크리스트
- [√] 코드가 잘 빌드됨
- [√] Linter
- [√] 모든 테스트 통과
- [√] kanban update