### PR TITLE
Article Status 기능 추가

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/article/controller/Article.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/controller/Article.kt
@@ -10,7 +10,7 @@ data class Article(
     val title: String,
     val content: String,
     val price: Int,
-    val status: String,
+    val status: Int,
     val location: String,
     var imagePresignedUrl: List<String>,
     val createdAt: Instant,

--- a/src/main/kotlin/com/toyProject7/karrot/article/controller/ArticleController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/controller/ArticleController.kt
@@ -48,6 +48,16 @@ class ArticleController(
         return ResponseEntity.ok("Deleted Successfully")
     }
 
+    @PutMapping("item/status/{articleId}")
+    fun updateStatus(
+        @RequestBody status: Int,
+        @PathVariable articleId: Long,
+        @AuthUser user: User,
+    ): ResponseEntity<String> {
+        articleService.updateStatus(status, articleId, user.id)
+        return ResponseEntity.ok("Status Updated Successfully")
+    }
+
     @PostMapping("/item/like/{articleId}")
     fun likeArticle(
         @PathVariable articleId: Long,

--- a/src/main/kotlin/com/toyProject7/karrot/article/controller/Item.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/controller/Item.kt
@@ -7,7 +7,7 @@ data class Item(
     val id: Long,
     val title: String,
     val price: Int,
-    val status: String,
+    val status: Int,
     val location: String,
     val imagePresignedUrl: String,
     val createdAt: Instant,

--- a/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleEntity.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleEntity.kt
@@ -30,7 +30,7 @@ class ArticleEntity(
     @Column(name = "price", nullable = false)
     var price: Int,
     @Column(name = "status", nullable = false)
-    var status: String,
+    var status: Int,
     @Column(name = "location", nullable = false)
     var location: String,
     @OneToMany(mappedBy = "article")

--- a/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleLikesRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleLikesRepository.kt
@@ -2,6 +2,8 @@ package com.toyProject7.karrot.article.persistence
 
 import com.toyProject7.karrot.user.persistence.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ArticleLikesRepository : JpaRepository<ArticleLikesEntity, String> {
     fun findTop10ByUserAndArticleIdLessThanOrderByArticleIdDesc(
@@ -14,8 +16,9 @@ interface ArticleLikesRepository : JpaRepository<ArticleLikesEntity, String> {
         articleId: Long,
     ): Boolean
 
+    @Query("SELECT al FROM article_likes al WHERE al.user.id = :userId AND al.article.id = :articleId")
     fun findByUserIdAndArticleId(
-        userId: String,
-        articleId: Long,
+        @Param("userId") userId: String,
+        @Param("articleId") articleId: Long,
     ): ArticleLikesEntity?
 }

--- a/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleRepository.kt
@@ -20,7 +20,7 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long> {
 
     @Modifying
     @Query("UPDATE articles a SET a.viewCount = a.viewCount + 1 WHERE a.id = :id")
-    fun incrementViewCount(id: Long): Long
+    fun incrementViewCount(id: Long): Int
 
     fun countBySellerId(id: String): Int
 }

--- a/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
@@ -38,7 +38,7 @@ class ArticleService(
                 title = request.title,
                 content = request.content,
                 price = request.price,
-                status = "판매 중",
+                status = 0,
                 location = request.location,
                 imageUrls = mutableListOf(),
                 createdAt = Instant.now(),
@@ -123,6 +123,17 @@ class ArticleService(
             imageService.deleteImageUrl(articleEntity.imageUrls)
         }
         articleRepository.delete(articleEntity)
+    }
+
+    @Transactional
+    fun updateStatus(
+        status: Int,
+        articleId: Long,
+        id: String,
+    ) {
+        val articleEntity = getArticleEntityById(articleId)
+        if (articleEntity.seller.id != id) throw ArticlePermissionDeniedException()
+        articleEntity.status = status
     }
 
     @Transactional

--- a/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
@@ -154,7 +154,9 @@ class ArticleService(
         articleId: Long,
         id: String,
     ) {
+        val article = articleRepository.findByIdOrNull(articleId) ?: throw ArticleNotFoundException()
         val toBeRemoved: ArticleLikesEntity = articleLikesRepository.findByUserIdAndArticleId(id, articleId) ?: return
+        article.articleLikes.remove(toBeRemoved)
         articleLikesRepository.delete(toBeRemoved)
     }
 


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #37

## ✨ 주요 변경 사항
- [ ] 백엔드: Article(중고거래글) Status 설정 기능 추가

---

## 📋 작업 내용
### 추가/변경된 내용
- Article(중고거래)의 Status의 설정 기능 추가

### 작업 상세 설명
1. updateStatus 함수 추가: ArticleEntity의 status 열의 자료형을 String에서 Int로 바꿨음. (0 = 판매중, 1 = 예약중, 2 = 판매완료)

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- 없음.

---

## 📎 참고 자료
- 없음.