### PR TITLE
Feed랑 Comment에 isLiked 정보 추가 & Feed 코드 최적화

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/comment/controller/Comment.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/controller/Comment.kt
@@ -11,6 +11,7 @@ data class Comment(
     val commentLikesCount: Int,
     val createdAt: Instant,
     val updatedAt: Instant,
+    var isLiked: Boolean = false,
 ) {
     companion object {
         fun fromEntity(entity: CommentEntity): Comment {

--- a/src/main/kotlin/com/toyProject7/karrot/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/controller/CommentController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -71,9 +72,10 @@ class CommentController(
 
     @GetMapping("/myfeed/comment")
     fun getFeedsByUserComments(
+        @RequestParam("feedId") feedId: Long,
         @AuthUser user: User,
     ): ResponseEntity<List<FeedPreview>> {
-        val feeds: List<FeedEntity> = commentService.getFeedsByUserComments(user.id)
+        val feeds: List<FeedEntity> = commentService.getFeedsByUserComments(feedId, user.id)
         val response =
             feeds.map { feed ->
                 FeedPreview.fromEntity(feed)

--- a/src/main/kotlin/com/toyProject7/karrot/comment/persistence/CommentLikesRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/persistence/CommentLikesRepository.kt
@@ -2,4 +2,9 @@ package com.toyProject7.karrot.comment.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CommentLikesRepository : JpaRepository<CommentLikesEntity, String>
+interface CommentLikesRepository : JpaRepository<CommentLikesEntity, String> {
+    fun existsByUserIdAndCommentId(
+        userId: String,
+        commentId: Long,
+    ): Boolean
+}

--- a/src/main/kotlin/com/toyProject7/karrot/comment/persistence/CommentRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/persistence/CommentRepository.kt
@@ -11,11 +11,12 @@ interface CommentRepository : JpaRepository<CommentEntity, Long> {
         """
         SELECT DISTINCT c.feed
         FROM comments c
-        WHERE c.user = :user
+        WHERE c.user = :user AND c.feed.id < :feedId
         ORDER BY c.feed.id DESC
         """,
     )
     fun findFeedsByUserComments(
         @Param("user") user: UserEntity,
+        @Param("feedId") feedId: Long,
     ): List<FeedEntity>
 }

--- a/src/main/kotlin/com/toyProject7/karrot/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/service/CommentService.kt
@@ -119,4 +119,12 @@ class CommentService(
     fun getCommentEntityById(commentId: Long): CommentEntity {
         return commentRepository.findByIdOrNull(commentId) ?: throw CommentNotFoundException()
     }
+
+    @Transactional
+    fun userLikesComment(
+        id: String,
+        commentId: Long,
+    ): Boolean {
+        return commentLikesRepository.existsByUserIdAndCommentId(id, commentId)
+    }
 }

--- a/src/main/kotlin/com/toyProject7/karrot/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/service/CommentService.kt
@@ -106,9 +106,12 @@ class CommentService(
     }
 
     @Transactional
-    fun getFeedsByUserComments(id: String): List<FeedEntity> {
+    fun getFeedsByUserComments(
+        feedId: Long,
+        id: String,
+    ): List<FeedEntity> {
         val user = userService.getUserEntityById(id)
-        val feeds = commentRepository.findFeedsByUserComments(user)
+        val feeds = commentRepository.findFeedsByUserComments(user, feedId)
         return feeds
     }
 

--- a/src/main/kotlin/com/toyProject7/karrot/feed/controller/Feed.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/controller/Feed.kt
@@ -17,6 +17,7 @@ data class Feed(
     val createdAt: Instant,
     val updatedAt: Instant,
     val viewCount: Int,
+    var isLiked: Boolean = false,
 ) {
     companion object {
         fun fromEntity(entity: FeedEntity): Feed {

--- a/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
@@ -69,8 +69,9 @@ class FeedController(
     @GetMapping("/feed/get/{feedId}")
     fun getFeed(
         @PathVariable feedId: Long,
+        @AuthUser user: User,
     ): ResponseEntity<Feed> {
-        return ResponseEntity.ok(feedService.getFeed(feedId))
+        return ResponseEntity.ok(feedService.getFeed(feedId, user.id))
     }
 
     @GetMapping("/feed")

--- a/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedLikesRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedLikesRepository.kt
@@ -2,10 +2,23 @@ package com.toyProject7.karrot.feed.persistence
 
 import com.toyProject7.karrot.user.persistence.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface FeedLikesRepository : JpaRepository<FeedLikesEntity, String> {
     fun findTop10ByUserAndFeedIdLessThanOrderByFeedIdDesc(
         user: UserEntity,
         feedId: Long,
     ): List<FeedLikesEntity>
+
+    fun existsByUserIdAndFeedId(
+        userId: String,
+        feedId: Long,
+    ): Boolean
+
+    @Query("SELECT fe FROM feed_likes fe WHERE fe.user.id = :userId AND fe.feed.id = :feedId")
+    fun findByUserIdAndFeedId(
+        @Param("userId") userId: String,
+        @Param("feedId") feedId: Long,
+    ): FeedLikesEntity?
 }

--- a/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedRepository.kt
@@ -1,20 +1,19 @@
 package com.toyProject7.karrot.feed.persistence
 
 import com.toyProject7.karrot.user.persistence.UserEntity
-import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface FeedRepository : JpaRepository<FeedEntity, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT r FROM feeds r WHERE r.id = :id")
-    fun findByIdWithWriteLock(id: Long): FeedEntity?
-
     fun findTop10ByIdBeforeOrderByIdDesc(id: Long): List<FeedEntity>
 
     fun findTop10ByAuthorAndIdLessThanOrderByIdDesc(
         author: UserEntity,
         id: Long,
     ): List<FeedEntity>
+
+    @Modifying
+    @Query("UPDATE feeds f SET f.viewCount = f.viewCount + 1 WHERE f.id = :id")
+    fun incrementViewCount(id: Long): Int
 }

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -25,7 +25,7 @@ class FeedService(
     private val feedRepository: FeedRepository,
     private val feedLikesRepository: FeedLikesRepository,
     private val userService: UserService,
-    private val commentService: CommentService,
+    @Lazy private val commentService: CommentService,
     @Lazy private val imageService: ImageService,
 ) {
     @Transactional


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #45

## ✨ 주요 변경 사항
- [ ] 백엔드: Feed랑 Comment에 isLiked 정보 추가
- [ ] 백엔드: Feed 코드 최적화 

---

## 📋 작업 내용
### 추가/변경된 내용
- Feed에 isLiked 정보 추가
- Comment에 isLiked 정보 추가
- Feed 코드 최적화

### 작업 상세 설명
1. Feed에 isLiked 정보 추가: getFeed를 할 때, getFeed를 한 사용자가 해당 Feed에 좋아요 한 상태이면, isLiked를 true로 바꿔서 반환하도록 함
2. Comment에 isLiked 정보 추가: getFeed를 할 때, 해당 Feed의 Comment들에 대해서도, 해당 Comment들 중에 좋아요를 눌렀던 Comment들의 isLiked를 true로 바꿔서 반환하도록 함
3. Feed 코드 최적화: 
3-1. getArticle에서 조회수를 증가시키는 방식으로 바꾸었음. DB에서 쿼리로 직접 바꾸는 방식.
3-2. FeedRepository의 Pessimistic Lock 삭제하였음. (ArticleRepository처럼 바꿈, 코드 통일 측면에서)
3-3. FeedService에서 findByIdWithWriteLock 사용하고 있었던 것들 다시 findByIdOrNull로 바꿈

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- 없음.
---

## 📎 참고 자료
- 없음.
