### PR TITLE
다른 사람 프로필에서 판매중인 물품 확인하기 & 코드 리팩토링

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
@@ -249,4 +249,9 @@ class ArticleService(
     fun getArticleEntityById(articleId: Long): ArticleEntity {
         return articleRepository.findByIdOrNull(articleId) ?: throw ArticleNotFoundException()
     }
+
+    @Transactional
+    fun getItemCount(id: String): Int {
+        return articleRepository.countBySellerId(id)
+    }
 }

--- a/src/main/kotlin/com/toyProject7/karrot/profile/controller/ProfileController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/profile/controller/ProfileController.kt
@@ -1,5 +1,6 @@
 package com.toyProject7.karrot.profile.controller
 
+import com.toyProject7.karrot.article.controller.Item
 import com.toyProject7.karrot.manner.controller.Manner
 import com.toyProject7.karrot.profile.service.ProfileService
 import com.toyProject7.karrot.review.controller.Review
@@ -38,6 +39,15 @@ class ProfileController(
     ): ResponseEntity<ProfileResponse> {
         val profile = profileService.getProfile(nickname)
         return ResponseEntity.ok(profile)
+    }
+
+    @GetMapping("/api/profile/{nickname}/sells")
+    fun getProfileSells(
+        @PathVariable nickname: String,
+        @RequestParam articleId: Long,
+    ): ResponseEntity<List<Item>> {
+        val itemList: List<Item> = profileService.getProfileSells(nickname, articleId)
+        return ResponseEntity.ok(itemList)
     }
 
     @PutMapping("/api/mypage/profile/edit")

--- a/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
@@ -16,6 +16,7 @@ import com.toyProject7.karrot.review.service.ReviewService
 import com.toyProject7.karrot.user.controller.User
 import com.toyProject7.karrot.user.persistence.UserEntity
 import com.toyProject7.karrot.user.service.UserService
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -25,9 +26,9 @@ import java.time.temporal.ChronoUnit
 class ProfileService(
     private val profileRepository: ProfileRepository,
     private val userService: UserService,
-    private val reviewService: ReviewService,
     private val articleService: ArticleService,
     private val imageService: ImageService,
+    @Lazy private val reviewService: ReviewService,
 ) {
     @Transactional
     fun getMyProfile(user: User): Profile {

--- a/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
@@ -1,6 +1,9 @@
 package com.toyProject7.karrot.profile.service
 
+import com.toyProject7.karrot.article.controller.Article
+import com.toyProject7.karrot.article.controller.Item
 import com.toyProject7.karrot.article.persistence.ArticleRepository
+import com.toyProject7.karrot.article.service.ArticleService
 import com.toyProject7.karrot.image.persistence.ImageUrlEntity
 import com.toyProject7.karrot.image.service.ImageService
 import com.toyProject7.karrot.manner.controller.Manner
@@ -14,6 +17,7 @@ import com.toyProject7.karrot.user.UserNotFoundException
 import com.toyProject7.karrot.user.controller.User
 import com.toyProject7.karrot.user.persistence.UserEntity
 import com.toyProject7.karrot.user.persistence.UserRepository
+import com.toyProject7.karrot.user.service.UserService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -23,8 +27,10 @@ import java.time.temporal.ChronoUnit
 class ProfileService(
     private val profileRepository: ProfileRepository,
     private val userRepository: UserRepository,
+    private val userService: UserService,
     private val reviewRepository: ReviewRepository,
     private val articleRepository: ArticleRepository,
+    private val articleService: ArticleService,
     private val imageService: ImageService,
 ) {
     @Transactional
@@ -49,6 +55,20 @@ class ProfileService(
         val profileEntity = profileRepository.findByUserId(user.id) ?: throw ProfileNotFoundException()
         val itemCount = getItemCount(user.id)
         return Profile.fromEntity(profileEntity, itemCount)
+    }
+
+    @Transactional
+    fun getProfileSells(
+        nickname: String,
+        articleId: Long,
+    ): List<Item> {
+        val user = userService.getUserEntityByNickname(nickname)
+        val articles = articleService.getArticlesBySeller(user.id!!, articleId)
+        val itemList =
+            articles.map { article ->
+                Item.fromArticle(Article.fromEntity(article))
+            }
+        return itemList
     }
 
     @Transactional

--- a/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
@@ -2,7 +2,6 @@ package com.toyProject7.karrot.profile.service
 
 import com.toyProject7.karrot.article.controller.Article
 import com.toyProject7.karrot.article.controller.Item
-import com.toyProject7.karrot.article.persistence.ArticleRepository
 import com.toyProject7.karrot.article.service.ArticleService
 import com.toyProject7.karrot.image.persistence.ImageUrlEntity
 import com.toyProject7.karrot.image.service.ImageService
@@ -12,11 +11,9 @@ import com.toyProject7.karrot.profile.controller.EditProfileRequest
 import com.toyProject7.karrot.profile.controller.Profile
 import com.toyProject7.karrot.profile.persistence.ProfileRepository
 import com.toyProject7.karrot.review.controller.Review
-import com.toyProject7.karrot.review.persistence.ReviewRepository
-import com.toyProject7.karrot.user.UserNotFoundException
+import com.toyProject7.karrot.review.service.ReviewService
 import com.toyProject7.karrot.user.controller.User
 import com.toyProject7.karrot.user.persistence.UserEntity
-import com.toyProject7.karrot.user.persistence.UserRepository
 import com.toyProject7.karrot.user.service.UserService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -26,10 +23,8 @@ import java.time.temporal.ChronoUnit
 @Service
 class ProfileService(
     private val profileRepository: ProfileRepository,
-    private val userRepository: UserRepository,
     private val userService: UserService,
-    private val reviewRepository: ReviewRepository,
-    private val articleRepository: ArticleRepository,
+    private val reviewService: ReviewService,
     private val articleService: ArticleService,
     private val imageService: ImageService,
 ) {
@@ -38,9 +33,8 @@ class ProfileService(
         val profileEntity = profileRepository.findByUserId(user.id) ?: throw ProfileNotFoundException()
         val itemCount = getItemCount(user.id)
 
-        val userEntity = userRepository.findById(user.id).orElseThrow { UserNotFoundException() }
+        val userEntity = userService.getUserEntityById(user.id)
         refreshPresignedUrlIfExpired(userEntity)
-        userRepository.save(userEntity)
         profileRepository.save(profileEntity)
 
         return Profile.fromEntity(profileEntity, itemCount)
@@ -48,9 +42,8 @@ class ProfileService(
 
     @Transactional
     fun getProfile(nickname: String): Profile {
-        val userEntity = userRepository.findByNickname(nickname) ?: throw UserNotFoundException()
+        val userEntity = userService.getUserEntityByNickname(nickname)
         refreshPresignedUrlIfExpired(userEntity)
-        userRepository.save(userEntity)
         val user = User.fromEntity(userEntity)
         val profileEntity = profileRepository.findByUserId(user.id) ?: throw ProfileNotFoundException()
         val itemCount = getItemCount(user.id)
@@ -76,13 +69,12 @@ class ProfileService(
         user: User,
         request: EditProfileRequest,
     ): Profile {
-        val userEntity = userRepository.findById(user.id).orElseThrow { UserNotFoundException() }
+        val userEntity = userService.getUserEntityById(user.id)
         val profileEntity = profileRepository.findByUserId(user.id) ?: throw ProfileNotFoundException()
         val itemCount = getItemCount(user.id)
 
         userEntity.nickname = request.nickname
         userEntity.location = request.location
-        userRepository.save(userEntity)
         if (userEntity.imageUrl != null) {
             val imageUrlListForDel: MutableList<ImageUrlEntity> = mutableListOf()
             imageUrlListForDel += userEntity.imageUrl!!
@@ -95,7 +87,6 @@ class ProfileService(
             val imagePutPresignedUrl: String = imageService.generatePutPresignedUrl(imageUrlEntity.s3)
             imageService.generateGetPresignedUrl(imageUrlEntity)
             userEntity.imageUrl = imageUrlEntity
-            userRepository.save(userEntity)
             profileRepository.save(profileEntity)
 
             val profile = Profile.fromEntity(profileEntity, itemCount)
@@ -113,13 +104,12 @@ class ProfileService(
         if (userEntity.imageUrl != null && ChronoUnit.MINUTES.between(userEntity.updatedAt, Instant.now()) >= 10) {
             imageService.generateGetPresignedUrl(userEntity.imageUrl!!)
             userEntity.updatedAt = Instant.now()
-            userRepository.save(userEntity)
         }
     }
 
     @Transactional
     fun getManner(nickname: String): List<Manner> {
-        val userEntity = userRepository.findByNickname(nickname) ?: throw UserNotFoundException()
+        val userEntity = userService.getUserEntityByNickname(nickname)
         val user = User.fromEntity(userEntity)
         val profileEntity = profileRepository.findByUserId(user.id) ?: throw ProfileNotFoundException()
         return Profile.fromEntity(profileEntity, 0).manners
@@ -130,13 +120,10 @@ class ProfileService(
         nickname: String,
         reviewId: Long,
     ): List<Review> {
-        return reviewRepository.findTop10BySellerNicknameOrBuyerNicknameAndIdBeforeOrderByCreatedAtDesc(nickname, nickname, reviewId).map {
-                reviewEntity ->
-            Review.fromEntity(reviewEntity)
-        }
+        return reviewService.getPreviousReviews(nickname, reviewId)
     }
 
     fun getItemCount(id: String): Int {
-        return articleRepository.countBySellerId(id)
+        return articleService.getItemCount(id)
     }
 }

--- a/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
@@ -9,6 +9,7 @@ import com.toyProject7.karrot.manner.controller.Manner
 import com.toyProject7.karrot.profile.ProfileNotFoundException
 import com.toyProject7.karrot.profile.controller.EditProfileRequest
 import com.toyProject7.karrot.profile.controller.Profile
+import com.toyProject7.karrot.profile.persistence.ProfileEntity
 import com.toyProject7.karrot.profile.persistence.ProfileRepository
 import com.toyProject7.karrot.review.controller.Review
 import com.toyProject7.karrot.review.service.ReviewService
@@ -125,5 +126,10 @@ class ProfileService(
 
     fun getItemCount(id: String): Int {
         return articleService.getItemCount(id)
+    }
+
+    @Transactional
+    fun getProfileEntityByUserId(userId: String): ProfileEntity {
+        return profileRepository.findByUserId(userId) ?: throw ProfileNotFoundException()
     }
 }

--- a/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/profile/service/ProfileService.kt
@@ -132,4 +132,9 @@ class ProfileService(
     fun getProfileEntityByUserId(userId: String): ProfileEntity {
         return profileRepository.findByUserId(userId) ?: throw ProfileNotFoundException()
     }
+
+    @Transactional
+    fun saveProfileEntity(profileEntity: ProfileEntity) {
+        profileRepository.save(profileEntity)
+    }
 }

--- a/src/main/kotlin/com/toyProject7/karrot/review/service/ReviewService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/review/service/ReviewService.kt
@@ -57,6 +57,17 @@ class ReviewService(
         return Review.fromEntity(reviewEntity)
     }
 
+    @Transactional
+    fun getPreviousReviews(
+        nickname: String,
+        reviewId: Long,
+    ): List<Review>  {
+        return reviewRepository.findTop10BySellerNicknameOrBuyerNicknameAndIdBeforeOrderByCreatedAtDesc(nickname, nickname, reviewId).map {
+                reviewEntity ->
+            Review.fromEntity(reviewEntity)
+        }
+    }
+
     private fun validateContent(content: String) {
         if (content.isBlank()) {
             throw ReviewContentLengthOutOfRangeException()

--- a/src/main/kotlin/com/toyProject7/karrot/user/service/UserService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/user/service/UserService.kt
@@ -1,7 +1,7 @@
 package com.toyProject7.karrot.user.service
 
 import com.toyProject7.karrot.profile.persistence.ProfileEntity
-import com.toyProject7.karrot.profile.persistence.ProfileRepository
+import com.toyProject7.karrot.profile.service.ProfileService
 import com.toyProject7.karrot.user.AuthenticateException
 import com.toyProject7.karrot.user.SignInInvalidPasswordException
 import com.toyProject7.karrot.user.SignInUserNotFoundException
@@ -29,8 +29,8 @@ import java.time.Instant
 @Service
 class UserService(
     private val userRepository: UserRepository,
-    private val profileRepository: ProfileRepository,
     private val normalUserRepository: NormalUserRepository,
+    private val profileService: ProfileService,
 ) {
     @Transactional
     fun signUp(
@@ -78,7 +78,7 @@ class UserService(
             ProfileEntity(
                 user = user,
             )
-        profileRepository.save(profileEntity)
+        profileService.saveProfileEntity(profileEntity)
 
         return User.fromEntity(user)
     }
@@ -135,8 +135,7 @@ class UserService(
                 ProfileEntity(
                     user = newUser,
                 )
-
-            profileRepository.save(profileEntity)
+            profileService.saveProfileEntity(profileEntity)
 
             User.fromEntity(savedUser) // Convert and return as User DTO
         }

--- a/src/main/kotlin/com/toyProject7/karrot/user/service/UserService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/user/service/UserService.kt
@@ -148,6 +148,11 @@ class UserService(
     }
 
     @Transactional
+    fun getUserEntityByNickname(nickname: String): UserEntity {
+        return userRepository.findByNickname(nickname) ?: throw AuthenticateException()
+    }
+
+    @Transactional
     fun loadUserPrincipal(id: String): UserPrincipal {
         val user =
             userRepository.findById(id)

--- a/src/main/kotlin/com/toyProject7/karrot/user/service/UserService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/user/service/UserService.kt
@@ -20,6 +20,7 @@ import com.toyProject7.karrot.user.persistence.UserEntity
 import com.toyProject7.karrot.user.persistence.UserPrincipal
 import com.toyProject7.karrot.user.persistence.UserRepository
 import org.mindrot.jbcrypt.BCrypt
+import org.springframework.context.annotation.Lazy
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
@@ -30,7 +31,7 @@ import java.time.Instant
 class UserService(
     private val userRepository: UserRepository,
     private val normalUserRepository: NormalUserRepository,
-    private val profileService: ProfileService,
+    @Lazy private val profileService: ProfileService,
 ) {
     @Transactional
     fun signUp(


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #55

## ✨ 주요 변경 사항
- [ ] 백엔드: 다른 사용자 프로필에서, 해당 사용자가 판매중인 물품 확인하는 기능
- [ ] 백엔드: 다른 패키지의 Repository로의 직접 접근을 할 수 없도록 몇몇 서비스 코드 리팩토링

---

## 📋 작업 내용
### 추가/변경된 내용
- 다른 사용자 프로필의 판매중인 물품 목록을 반환하는 기능 추가.
- 몇몇 서비스에서 다른 패키지의 Repository로의 직접 접근을 할 수 없도록 하였음. 

### 작업 상세 설명
1. 다른 사용자의 판매물품 반환 기능: ArticleService의 getArticlesBySeller 함수를 재사용. 해당 사용자가 '판매 중인' 물품 목록을 반환해야 하므로. 
2. Service <-> Repository 간의 관계 지키기: 각 ReviewService, ProfileService, UserService 에서 다른 패키지의 레포지토리에 접근해야하는 경우가 생기면, 꼭 해당 레포지토리의 서비스를 거쳐서 접근해야하도록 수정하였음.
3. 불필요한 save 함수 삭제
4. 참조 순환 문제: ReviewService, ProfileService, UserService를 2와 같이 바꾸니까 발생한 참조 순환 오류를 @Lazy 어노테이션을 활용하여 처리함.

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- ReviewService, ProfileService, UserService 코드를 리팩토링 하는 과정에서 코드의 실행 동작이 바뀐 것은 없음. 최적화 차원과 안정적인 DB구조를 위해서 바꾼 것.
---

## 📎 참고 자료
- 없음.
