### PR TITLE
"내 동네생활 > 댓글 단 글" 에서 피드 목록을 불러오지 않던 문제를 수정하였음.

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/controller/CommentController.kt
@@ -1,27 +1,21 @@
 package com.toyProject7.karrot.comment.controller
 
-import com.toyProject7.karrot.comment.persistence.CommentRepository
 import com.toyProject7.karrot.comment.service.CommentService
-import com.toyProject7.karrot.feed.controller.FeedPreview
-import com.toyProject7.karrot.feed.persistence.FeedEntity
 import com.toyProject7.karrot.user.AuthUser
 import com.toyProject7.karrot.user.controller.User
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api")
 class CommentController(
     private val commentService: CommentService,
-    private val commentRepository: CommentRepository,
 ) {
     @PostMapping("/comment/post/{feedId}")
     fun postComment(
@@ -68,19 +62,6 @@ class CommentController(
     ): ResponseEntity<String> {
         commentService.unlikeComment(commentId, user.id)
         return ResponseEntity.ok("Unliked Successfully")
-    }
-
-    @GetMapping("/myfeed/comment")
-    fun getFeedsByUserComments(
-        @RequestParam("feedId") feedId: Long,
-        @AuthUser user: User,
-    ): ResponseEntity<List<FeedPreview>> {
-        val feeds: List<FeedEntity> = commentService.getFeedsByUserComments(feedId, user.id)
-        val response =
-            feeds.map { feed ->
-                FeedPreview.fromEntity(feed)
-            }
-        return ResponseEntity.ok(response)
     }
 }
 

--- a/src/main/kotlin/com/toyProject7/karrot/comment/persistence/CommentRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/persistence/CommentRepository.kt
@@ -1,22 +1,7 @@
 package com.toyProject7.karrot.comment.persistence
 
-import com.toyProject7.karrot.feed.persistence.FeedEntity
-import com.toyProject7.karrot.user.persistence.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
 interface CommentRepository : JpaRepository<CommentEntity, Long> {
-    @Query(
-        """
-        SELECT DISTINCT c.feed
-        FROM comments c
-        WHERE c.user = :user AND c.feed.id < :feedId
-        ORDER BY c.feed.id DESC
-        """,
-    )
-    fun findFeedsByUserComments(
-        @Param("user") user: UserEntity,
-        @Param("feedId") feedId: Long,
-    ): List<FeedEntity>
+    fun findByUserId(userId: String): List<CommentEntity>
 }

--- a/src/main/kotlin/com/toyProject7/karrot/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/comment/service/CommentService.kt
@@ -8,7 +8,6 @@ import com.toyProject7.karrot.comment.persistence.CommentEntity
 import com.toyProject7.karrot.comment.persistence.CommentLikesEntity
 import com.toyProject7.karrot.comment.persistence.CommentLikesRepository
 import com.toyProject7.karrot.comment.persistence.CommentRepository
-import com.toyProject7.karrot.feed.persistence.FeedEntity
 import com.toyProject7.karrot.feed.service.FeedService
 import com.toyProject7.karrot.user.service.UserService
 import org.springframework.data.repository.findByIdOrNull
@@ -106,13 +105,8 @@ class CommentService(
     }
 
     @Transactional
-    fun getFeedsByUserComments(
-        feedId: Long,
-        id: String,
-    ): List<FeedEntity> {
-        val user = userService.getUserEntityById(id)
-        val feeds = commentRepository.findFeedsByUserComments(user, feedId)
-        return feeds
+    fun getCommentsByUser(id: String): List<CommentEntity> {
+        return commentRepository.findByUserId(id)
     }
 
     @Transactional

--- a/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
@@ -111,6 +111,19 @@ class FeedController(
             }
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/myfeed/comment")
+    fun getFeedsThatUserComments(
+        @RequestParam("feedId") feedId: Long,
+        @AuthUser user: User,
+    ): ResponseEntity<List<FeedPreview>> {
+        val feeds: List<FeedEntity> = feedService.getFeedsThatUserComments(user.id, feedId)
+        val response =
+            feeds.map { feed ->
+                FeedPreview.fromEntity(feed)
+            }
+        return ResponseEntity.ok(response)
+    }
 }
 
 data class PostFeedRequest(

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -219,11 +219,14 @@ class FeedService(
         feedId: Long,
     ): List<FeedEntity> {
         val comments: List<CommentEntity> = commentService.getCommentsByUser(id)
-        return comments
-            .map { it.feed }
-            .filter { it.id!! < feedId }
-            .distinctBy { it.id }
-            .sortedByDescending { it.id }
+        val feeds: List<FeedEntity> =
+            comments
+                .map { it.feed }
+                .filter { it.id!! < feedId }
+                .distinctBy { it.id }
+                .sortedByDescending { it.id }
+        if (feeds.size < 10) return feeds
+        return feeds.subList(0, 10)
     }
 
     @Transactional

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -214,6 +214,19 @@ class FeedService(
     }
 
     @Transactional
+    fun getFeedsThatUserComments(
+        id: String,
+        feedId: Long,
+    ): List<FeedEntity> {
+        val comments: List<CommentEntity> = commentService.getCommentsByUser(id)
+        return comments
+            .map { it.feed }
+            .filter { it.id!! < feedId }
+            .distinctBy { it.id }
+            .sortedByDescending { it.id }
+    }
+
+    @Transactional
     fun getFeedEntityById(feedId: Long): FeedEntity {
         return feedRepository.findByIdOrNull(feedId) ?: throw FeedNotFoundException()
     }


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #41

## ✨ 주요 변경 사항
- [x] 백엔드: "내 동네생활 > 댓글 단 글" 문제 수정

---

## 📋 작업 내용
### 추가/변경된 내용
- "내 동네생활 > 댓글 단 글" 문제 수정

### 작업 상세 설명
1. "내 동네생활 > 댓글 단 글" 에서 피드 목록을 불러오지 않던 문제를 수정하였음.
1-1. CommentRepository에서 함수를 통해 FeedEntity 리스트를 불러오고자 하였으나, Spring Data JPA는 메서드 이름 기반 쿼리를 사용할 때, 기본적으로 관리하는 엔티티에서만 검색하거나 반환할 수 있으므로 안됐던 것. CommentRepository에서는 CommentEntity만 반환 받을 수 있는 것. 고로, 1-2와 같은 방법 고안하여 해결하였음.
1-2. 기능 작동 과정: FeedService의 getFeedsThatUserComments 함수 -> CommentRepository로 가서 User가 작성한 모든 댓글을 리스트로 가져옴.( List<CommentEntity> ) -> getFeedsThatUserComments 에서 List<CommentEntity>를 List<FeedEntity> 로 매핑 ( List<CommentEntity> to List<FeedEntity> ) -> filter 함수를 통해 피드엔티티의 id가 feedId 보다 작은 FeedEntity만 남김 -> distinctBy 함수를 이용해 중복되는 FeedEntity를 제거함 -> sortedByDescending 함수를 이용해 FeedEntity를 feedId 기준 내림차순 정렬 -> 최대 10개의 FeedEntity 만 반환

---

## ✅ 체크리스트
- [x] 코드가 잘 빌드됨
- [x] Linter
- [x] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- 1-2에 List<CommentEntity> 를 저희가 필요한 10개의 List<FeedEntity>로 바꾸는 과정은 직접 FeedService.kt의 getFeedsThatUserComments 부분 확인하시는게 이해가 빠를듯 합니다!

---

## 📎 참고 자료
- 없음.
