### PR TITLE
edit 시에 PresignedUrl을 제대로 반환하지 않는 문제 해결

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleEntity.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleEntity.kt
@@ -35,7 +35,8 @@ class ArticleEntity(
     var status: Int,
     @Column(name = "location", nullable = false)
     var location: String,
-    @OneToMany(mappedBy = "article")
+    @OneToMany
+    @JoinColumn(name = "image_url", nullable = true)
     var imageUrls: MutableList<ImageUrlEntity> = mutableListOf(),
     @OneToMany(mappedBy = "article")
     var articleLikes: MutableList<ArticleLikesEntity> = mutableListOf(),

--- a/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
@@ -28,7 +28,7 @@ class ArticleService(
     private val articleRepository: ArticleRepository,
     private val articleLikesRepository: ArticleLikesRepository,
     private val userService: UserService,
-    @Lazy private val imageService: ImageService,
+    private val imageService: ImageService,
     @Lazy private val chatRoomService: ChatRoomService,
 ) {
     @Transactional

--- a/src/main/kotlin/com/toyProject7/karrot/auction/persistence/AuctionEntity.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/auction/persistence/AuctionEntity.kt
@@ -37,7 +37,8 @@ class AuctionEntity(
     var status: Int,
     @Column(name = "location", nullable = false)
     var location: String,
-    @OneToMany(mappedBy = "auction")
+    @OneToMany
+    @JoinColumn(name = "image_url", nullable = true)
     var imageUrls: MutableList<ImageUrlEntity> = mutableListOf(),
     @OneToMany(mappedBy = "auction")
     var auctionLikes: MutableList<AuctionLikesEntity> = mutableListOf(),

--- a/src/main/kotlin/com/toyProject7/karrot/auction/service/AuctionService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/auction/service/AuctionService.kt
@@ -17,7 +17,6 @@ import com.toyProject7.karrot.auction.persistence.AuctionRepository
 import com.toyProject7.karrot.image.persistence.ImageUrlEntity
 import com.toyProject7.karrot.image.service.ImageService
 import com.toyProject7.karrot.user.service.UserService
-import org.springframework.context.annotation.Lazy
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -29,7 +28,7 @@ class AuctionService(
     private val auctionRepository: AuctionRepository,
     private val auctionLikesRepository: AuctionLikesRepository,
     private val userService: UserService,
-    @Lazy private val imageService: ImageService,
+    private val imageService: ImageService,
 ) {
     @Transactional
     fun updatePrice(auctionMessage: AuctionMessage): AuctionMessage {

--- a/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedEntity.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedEntity.kt
@@ -27,7 +27,8 @@ class FeedEntity(
     var content: String,
     @Column(name = "tag", nullable = false)
     var tag: String,
-    @OneToMany(mappedBy = "feed")
+    @OneToMany
+    @JoinColumn(name = "image_url", nullable = true)
     var imageUrls: MutableList<ImageUrlEntity> = mutableListOf(),
     @OneToMany(mappedBy = "feed")
     var feedLikes: MutableList<FeedLikesEntity> = mutableListOf(),

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -26,7 +26,7 @@ class FeedService(
     private val feedLikesRepository: FeedLikesRepository,
     private val userService: UserService,
     @Lazy private val commentService: CommentService,
-    @Lazy private val imageService: ImageService,
+    private val imageService: ImageService,
 ) {
     @Transactional
     fun postFeed(

--- a/src/main/kotlin/com/toyProject7/karrot/image/persistence/ImageUrlEntity.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/image/persistence/ImageUrlEntity.kt
@@ -1,30 +1,16 @@
 package com.toyProject7.karrot.image.persistence
 
-import com.toyProject7.karrot.article.persistence.ArticleEntity
-import com.toyProject7.karrot.auction.persistence.AuctionEntity
-import com.toyProject7.karrot.feed.persistence.FeedEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 
 @Entity(name = "image_urls")
 class ImageUrlEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    @ManyToOne
-    @JoinColumn(name = "article_id", nullable = true)
-    var article: ArticleEntity? = null,
-    @ManyToOne
-    @JoinColumn(name = "feed_id", nullable = true)
-    var feed: FeedEntity? = null,
-    @ManyToOne
-    @JoinColumn(name = "auction_id", nullable = true)
-    var auction: AuctionEntity? = null,
     @Column(name = "s3", nullable = false, length = 512)
     var s3: String,
     @Column(name = "presigned", nullable = false, length = 512)

--- a/src/main/kotlin/com/toyProject7/karrot/image/service/ImageService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/image/service/ImageService.kt
@@ -1,8 +1,5 @@
 package com.toyProject7.karrot.image.service
 
-import com.toyProject7.karrot.article.service.ArticleService
-import com.toyProject7.karrot.auction.service.AuctionService
-import com.toyProject7.karrot.feed.service.FeedService
 import com.toyProject7.karrot.image.ImageDeleteException
 import com.toyProject7.karrot.image.ImagePresignedUrlCreateException
 import com.toyProject7.karrot.image.ImageS3UrlCreateException
@@ -25,9 +22,6 @@ class ImageService(
     private val s3Client: S3Client,
     private val s3Presigner: S3Presigner,
     private val imageUrlRepository: ImageUrlRepository,
-    private val articleService: ArticleService,
-    private val feedService: FeedService,
-    private val auctionService: AuctionService,
 ) {
     @Transactional
     fun postImageUrl(
@@ -39,17 +33,6 @@ class ImageService(
             ImageUrlEntity(
                 s3 = generateS3Path(type, typeId, imageIndex),
             )
-        when (type) {
-            "article" -> {
-                imageUrlEntity.article = articleService.getArticleEntityById(typeId)
-            }
-            "feed" -> {
-                imageUrlEntity.feed = feedService.getFeedEntityById(typeId)
-            }
-            "auction" -> {
-                imageUrlEntity.auction = auctionService.getAuctionEntityById(typeId)
-            }
-        }
         imageUrlRepository.save(imageUrlEntity)
 
         return imageUrlEntity


### PR DESCRIPTION
…esignedUrl with no delay

# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #36 #26 #15 #14 #13

## ✨ 주요 변경 사항
- [ ] 백엔드: Article, Feed, Auction 게시물 수정시에 PresignedUrl을 제대로 반환하지 않던 문제 해결

---

## 📋 작업 내용
### 추가/변경된 내용
- ImageUrlEntity 수정
- ImageService 수정
- Article, Feed, Auction Entity 수정
- Article, Feed, Auction Service 수정

### 작업 상세 설명
1. ImageUrlEntity 수정: Article, Feed, Auction 과의 관계를 끊었음.
2. ImageService 수정: Article, Feed, Auction Service를 더 이상 사용하지 않음. 그러므로 각 Service에서 ImageService를 사용할때 @Lazy 를 사용하지 않도록 하였음
3. Article, Feed, Auction Entity 수정: @OneToMany에서 매핑 제거, @JoinColumn 추가
4. Article, Feed, Auction Service 수정: @Lazy를 제거하고 ImageService 사용

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- 없음.

---

## 📎 참고 자료
- 없음.