### PR TITLE
중고거래 및 동네생활 게시물 검색 기능 추가

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/article/controller/ArticleController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/controller/ArticleController.kt
@@ -138,6 +138,20 @@ class ArticleController(
             }
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/item/search/{articleId}")
+    fun searchArticles(
+        @RequestBody request: SearchRequest,
+        @PathVariable articleId: Long,
+        @AuthUser user: User,
+    ): ResponseEntity<List<Item>> {
+        val articles = articleService.searchArticle(request, articleId)
+        val response: List<Item> =
+            articles.map { article ->
+                Item.fromArticle(Article.fromEntity(article))
+            }
+        return ResponseEntity.ok(response)
+    }
 }
 
 data class PostArticleRequest(
@@ -151,6 +165,10 @@ data class PostArticleRequest(
 
 data class UpdateStatusRequest(
     val status: Int,
+)
+
+data class SearchRequest(
+    val text: String,
 )
 
 data class ArticleResponse(

--- a/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/persistence/ArticleRepository.kt
@@ -23,4 +23,10 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long> {
     fun incrementViewCount(id: Long): Int
 
     fun countBySellerId(id: String): Int
+
+    fun findTop10ByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseAndIdLessThanOrderByIdDesc(
+        title: String,
+        content: String,
+        id: Long,
+    ): List<ArticleEntity>
 }

--- a/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
@@ -4,6 +4,7 @@ import com.toyProject7.karrot.article.ArticleNotFoundException
 import com.toyProject7.karrot.article.ArticlePermissionDeniedException
 import com.toyProject7.karrot.article.controller.Article
 import com.toyProject7.karrot.article.controller.PostArticleRequest
+import com.toyProject7.karrot.article.controller.SearchRequest
 import com.toyProject7.karrot.article.controller.UpdateStatusRequest
 import com.toyProject7.karrot.article.persistence.ArticleEntity
 import com.toyProject7.karrot.article.persistence.ArticleLikesEntity
@@ -246,6 +247,22 @@ class ArticleService(
     ): List<ArticleEntity> {
         val buyer = userService.getUserEntityById(id)
         val articles = articleRepository.findTop10ByBuyerAndIdLessThanOrderByIdDesc(buyer, articleId)
+        refreshPresignedUrlIfExpired(articles)
+        return articles
+    }
+
+    @Transactional
+    fun searchArticle(
+        request: SearchRequest,
+        articleId: Long,
+    ): List<ArticleEntity> {
+        val text = request.text
+        val articles =
+            articleRepository.findTop10ByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseAndIdLessThanOrderByIdDesc(
+                text,
+                text,
+                articleId,
+            )
         refreshPresignedUrlIfExpired(articles)
         return articles
     }

--- a/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
@@ -124,6 +124,20 @@ class FeedController(
             }
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/feed/search/{feedId}")
+    fun searchFeeds(
+        @RequestBody request: SearchRequest,
+        @PathVariable feedId: Long,
+        @AuthUser user: User,
+    ): ResponseEntity<List<FeedPreview>> {
+        val feeds = feedService.searchFeed(request, feedId)
+        val response: List<FeedPreview> =
+            feeds.map { feed ->
+                FeedPreview.fromEntity(feed)
+            }
+        return ResponseEntity.ok(response)
+    }
 }
 
 data class PostFeedRequest(
@@ -131,4 +145,8 @@ data class PostFeedRequest(
     val content: String,
     val tag: String,
     val imageCount: Int,
+)
+
+data class SearchRequest(
+    val text: String,
 )

--- a/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedRepository.kt
@@ -16,4 +16,10 @@ interface FeedRepository : JpaRepository<FeedEntity, Long> {
     @Modifying
     @Query("UPDATE feeds f SET f.viewCount = f.viewCount + 1 WHERE f.id = :id")
     fun incrementViewCount(id: Long): Int
+
+    fun findTop10ByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseAndIdLessThanOrderByIdDesc(
+        title: String,
+        content: String,
+        id: Long,
+    ): List<FeedEntity>
 }

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -1,12 +1,12 @@
 package com.toyProject7.karrot.feed.service
 
-import com.toyProject7.karrot.article.persistence.ArticleEntity
 import com.toyProject7.karrot.comment.persistence.CommentEntity
 import com.toyProject7.karrot.comment.service.CommentService
 import com.toyProject7.karrot.feed.FeedNotFoundException
 import com.toyProject7.karrot.feed.FeedPermissionDeniedException
 import com.toyProject7.karrot.feed.controller.Feed
 import com.toyProject7.karrot.feed.controller.PostFeedRequest
+import com.toyProject7.karrot.feed.controller.SearchRequest
 import com.toyProject7.karrot.feed.persistence.FeedEntity
 import com.toyProject7.karrot.feed.persistence.FeedLikesEntity
 import com.toyProject7.karrot.feed.persistence.FeedLikesRepository
@@ -231,11 +231,13 @@ class FeedService(
     }
 
     @Transactional
-    fun searchArticle(
-        text: String,
+    fun searchFeed(
+        request: SearchRequest,
         feedId: Long,
-    ): List<ArticleEntity> {
-        val feeds = feedRepository.findTop10ByText(text)
+    ): List<FeedEntity> {
+        val text = request.text
+        val feeds =
+            feedRepository.findTop10ByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseAndIdLessThanOrderByIdDesc(text, text, feedId)
         refreshPresignedUrlIfExpired(feeds)
         return feeds
     }

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -1,5 +1,6 @@
 package com.toyProject7.karrot.feed.service
 
+import com.toyProject7.karrot.article.persistence.ArticleEntity
 import com.toyProject7.karrot.comment.persistence.CommentEntity
 import com.toyProject7.karrot.comment.service.CommentService
 import com.toyProject7.karrot.feed.FeedNotFoundException
@@ -227,6 +228,16 @@ class FeedService(
                 .sortedByDescending { it.id }
         if (feeds.size < 10) return feeds
         return feeds.subList(0, 10)
+    }
+
+    @Transactional
+    fun searchArticle(
+        text: String,
+        feedId: Long,
+    ): List<ArticleEntity> {
+        val feeds = feedRepository.findTop10ByText(text)
+        refreshPresignedUrlIfExpired(feeds)
+        return feeds
     }
 
     @Transactional


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #84

## ✨ 주요 변경 사항
- [ ] 백엔드: 중고거래 및 동네생활 게시물 검색 기능 추가

---

## 📋 작업 내용
### 추가/변경된 내용
- Article 검색 기능 추가
- Feed 검색 기능 추가

### 작업 상세 설명
1. Article 검색 기능:
1-1. ArticleController에 searchArticles API, SearchRequest data class 추가
1-2. ArticleService에 searchArticle 함수 추가
1-3. ArticleRepository에 검색 문자열이 제목이나 내용에 포함되어 있으면 해당 엔티티 목록을 반환하는 함수 추가
2. Feed 검색 기능:
2-1. FeedController에 searchFeeds API, SearchRequest data class 추가
2-2. FeedService에 searchFeed 함수 추가
2-3. FeedRepository에 검색 문자열이 제목이나 내용에 포함되어 있으면 해당 엔티티 목록을 반환하는 함수 추가

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- 없음.
---

## 📎 참고 자료
- 없음.
