### PR TITLE
동네생활 게시물 인기순 목록 반환 기능

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
@@ -125,9 +125,9 @@ class FeedController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/feed/popular/{feedId}")
+    @GetMapping("/feed/popular")
     fun getPopularFeeds(
-        @PathVariable feedId: Long,
+        @RequestParam("feedId") feedId: Long,
         @AuthUser user: User,
     ): ResponseEntity<List<FeedPreview>> {
         val feeds = feedService.getPopularFeeds(feedId)

--- a/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/controller/FeedController.kt
@@ -125,6 +125,19 @@ class FeedController(
         return ResponseEntity.ok(response)
     }
 
+    @GetMapping("/feed/popular/{feedId}")
+    fun getPopularFeeds(
+        @PathVariable feedId: Long,
+        @AuthUser user: User,
+    ): ResponseEntity<List<FeedPreview>> {
+        val feeds = feedService.getPopularFeeds(feedId)
+        val response: List<FeedPreview> =
+            feeds.map { feed ->
+                FeedPreview.fromEntity(feed)
+            }
+        return ResponseEntity.ok(response)
+    }
+
     @GetMapping("/feed/search/{feedId}")
     fun searchFeeds(
         @RequestBody request: SearchRequest,

--- a/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedRepository.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/persistence/FeedRepository.kt
@@ -22,4 +22,6 @@ interface FeedRepository : JpaRepository<FeedEntity, Long> {
         content: String,
         id: Long,
     ): List<FeedEntity>
+
+    fun findTop10ByIdLessThanOrderByViewCountDescIdDesc(id: Long): List<FeedEntity>
 }

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -231,6 +231,13 @@ class FeedService(
     }
 
     @Transactional
+    fun getPopularFeeds(feedId: Long): List<FeedEntity> {
+        val feeds = feedRepository.findTop10ByIdLessThanOrderByViewCountDescIdDesc(feedId)
+        refreshPresignedUrlIfExpired(feeds)
+        return feeds
+    }
+
+    @Transactional
     fun searchFeed(
         request: SearchRequest,
         feedId: Long,


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #86

## ✨ 주요 변경 사항
- [ ] 백엔드: 동네생활 게시물 인기순 반환 기능

---

## 📋 작업 내용
### 추가/변경된 내용
- 동네생활 게시물 인기순 목록 반환 기능 추가

### 작업 상세 설명
1. FeedRepository.kt: FeedId가 feedId보다 작으면서, 조회수 내림차순 정렬해 10개의 FeedEntity를 반환하는 함수 추가
2. FeedController.kt: getPopularFeeds 함수 추가
3. FeedService.kt: getPopularFeeds 함수 추가 - 해당 함수에서 1에서 추가한 함수를 이용해 List<FeedEntity>를 반환

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- 없음.

---

## 📎 참고 자료
- 없음.