### PR TITLE
경매 refresh 시간 단축, 경매 판매자와 구매자가 같을 경우 채팅방 안 만들게 설정

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/auction/service/AuctionService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/auction/service/AuctionService.kt
@@ -208,7 +208,7 @@ class AuctionService(
         return auctionRepository.findByIdOrNull(auctionId) ?: throw AuctionNotFoundException()
     }
 
-    @Scheduled(fixedRate = 60000) // Run every minute
+    @Scheduled(fixedRate = 10000)
     fun checkAndEndAuctions() {
         val now = Instant.now()
         val endedAuctions = auctionRepository.findByEndTimeBeforeAndStatus(now, 0)
@@ -237,10 +237,13 @@ class AuctionService(
                 isDummy = 1,
             )
         articleRepository.save(articleEntity)
-        chatRoomService.createChatRoom(
-            articleEntity.id ?: throw IllegalArgumentException("Article ID cannot be null"),
-            articleEntity.seller.id ?: throw IllegalArgumentException("Seller ID cannot be null"),
-            articleEntity.buyer?.id ?: throw IllegalArgumentException("Buyer ID cannot be null"),
-        )
+        if (auction.seller.id != auction.bidder?.id)
+            {
+                chatRoomService.createChatRoom(
+                    articleEntity.id ?: throw IllegalArgumentException("Article ID cannot be null"),
+                    articleEntity.seller.id ?: throw IllegalArgumentException("Seller ID cannot be null"),
+                    articleEntity.buyer?.id ?: throw IllegalArgumentException("Buyer ID cannot be null"),
+                )
+            }
     }
 }

--- a/src/main/kotlin/com/toyProject7/karrot/auction/service/AuctionService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/auction/service/AuctionService.kt
@@ -237,13 +237,12 @@ class AuctionService(
                 isDummy = 1,
             )
         articleRepository.save(articleEntity)
-        if (auction.seller.id != auction.bidder?.id)
-            {
-                chatRoomService.createChatRoom(
-                    articleEntity.id ?: throw IllegalArgumentException("Article ID cannot be null"),
-                    articleEntity.seller.id ?: throw IllegalArgumentException("Seller ID cannot be null"),
-                    articleEntity.buyer?.id ?: throw IllegalArgumentException("Buyer ID cannot be null"),
-                )
-            }
+        if (auction.seller.id != auction.bidder?.id) {
+            chatRoomService.createChatRoom(
+                articleEntity.id ?: throw IllegalArgumentException("Article ID cannot be null"),
+                articleEntity.seller.id ?: throw IllegalArgumentException("Seller ID cannot be null"),
+                articleEntity.buyer?.id ?: throw IllegalArgumentException("Buyer ID cannot be null"),
+            )
+        }
     }
 }


### PR DESCRIPTION
## ✨ 주요 변경 사항
- [ ] 백엔드: Spring Boot 관련 기능 추가/수정

---

## 📋 작업 내용
### 추가/변경된 내용
- 경매 refresh 시간 10초로 단축, 경매 판매자와 구매자가 같을 경우 채팅방 안 만들게 설정

### 작업 상세 설명
1. **경매 refresh 시간 단축**: 1분에서 10초로 단축
2. **자신과의 채팅방**: 경매 판매자와 구매자가 같을 경우 채팅방 안 만들게 설정

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

