### PR TITLE
중고거래 및 동네생활 홈에 올라온 게시물의 작성자의 프로필 이미지가 항상 최신 PresignedUrl을 가지고 있는지 확인하는 기능

### DIFF
--- a/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/article/service/ArticleService.kt
@@ -14,6 +14,7 @@ import com.toyProject7.karrot.chatRoom.persistence.ChatRoomEntity
 import com.toyProject7.karrot.chatRoom.service.ChatRoomService
 import com.toyProject7.karrot.image.persistence.ImageUrlEntity
 import com.toyProject7.karrot.image.service.ImageService
+import com.toyProject7.karrot.profile.service.ProfileService
 import com.toyProject7.karrot.user.controller.User
 import com.toyProject7.karrot.user.service.UserService
 import org.springframework.context.annotation.Lazy
@@ -29,6 +30,7 @@ class ArticleService(
     private val articleLikesRepository: ArticleLikesRepository,
     private val userService: UserService,
     private val imageService: ImageService,
+    @Lazy private val profileService: ProfileService,
     @Lazy private val chatRoomService: ChatRoomService,
 ) {
     @Transactional
@@ -204,6 +206,7 @@ class ArticleService(
                 article.updatedAt = Instant.now()
                 articleRepository.save(article)
             }
+            profileService.refreshPresignedUrlIfExpired(article.seller)
         }
     }
 

--- a/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/toyProject7/karrot/feed/service/FeedService.kt
@@ -12,6 +12,7 @@ import com.toyProject7.karrot.feed.persistence.FeedLikesRepository
 import com.toyProject7.karrot.feed.persistence.FeedRepository
 import com.toyProject7.karrot.image.persistence.ImageUrlEntity
 import com.toyProject7.karrot.image.service.ImageService
+import com.toyProject7.karrot.profile.service.ProfileService
 import com.toyProject7.karrot.user.service.UserService
 import org.springframework.context.annotation.Lazy
 import org.springframework.data.repository.findByIdOrNull
@@ -27,6 +28,7 @@ class FeedService(
     private val userService: UserService,
     @Lazy private val commentService: CommentService,
     private val imageService: ImageService,
+    private val profileService: ProfileService,
 ) {
     @Transactional
     fun postFeed(
@@ -184,6 +186,7 @@ class FeedService(
                 feed.updatedAt = Instant.now()
                 feedRepository.save(feed)
             }
+            profileService.refreshPresignedUrlIfExpired(feed.author)
         }
     }
 


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #97

## ✨ 주요 변경 사항
- [ ] 백엔드: 게시물을 올린 사용자의 이미지 갱신 확인

---

## 📋 작업 내용
### 추가/변경된 내용
- 중고거래 및 동네생활 홈에 올라온 게시물의 작성자의 프로필 이미지가 항상 최신 PresignedUrl을 가지고 있는지 확인하는 기능 추가하였음.

### 작업 상세 설명
1. profileService에서 유저의 이미지를 갱신하는 함수를 ArticleService와 FeedService로 가져와서, refreshPresignedUrlIfExpired 함수에서 유저의 이미지도 확인하도록 하였음.
2. 원래는 직접 유저의 프로필을 클릭해야만 유저의 이미지가 갱신됐었기 때문에, 만약 다른 사용자들이 어떤 사용자의 유저 프로필을 한번도 들어가지 않았는다면, 해당 사용자의 이미지는 스스로가 '나의 당근' 탭으로 들어갈때만 갱신됨.
3. 2를 방지하기 위해서 올라온 게시물에 한해서, 해당 게시물을 올린 사용자의 이미지를 갱신해주는 과정을 추가한 것.

---

## ✅ 체크리스트
- [ ] 코드가 잘 빌드됨
- [ ] Linter
- [ ] 모든 테스트 통과
- [ ] kanban update

---

## ⚠️ 주의 사항
- 없음.

---

## 📎 참고 자료
- 없음.
